### PR TITLE
Ignore remaining PNG data after IEND chunk

### DIFF
--- a/src/png/image.rs
+++ b/src/png/image.rs
@@ -41,7 +41,7 @@ impl Png {
             let chunk = PngChunk::from_bytes(&mut b)?;
 
             // Often PNG images found in the internet contain garbage after IEND chunk.
-            // Most PNG parser simply ignore everything after IEND chunk
+            // Most PNG parsers simply ignore everything after IEND chunk
             let is_end = chunk.kind() == CHUNK_IEND;
             chunks.push(chunk);
 

--- a/src/png/image.rs
+++ b/src/png/image.rs
@@ -14,6 +14,7 @@ pub(crate) const SIGNATURE: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 
 
 pub const CHUNK_ICCP: [u8; 4] = [b'i', b'C', b'C', b'P'];
 pub const CHUNK_EXIF: [u8; 4] = [b'e', b'X', b'I', b'f'];
+pub const CHUNK_IEND: [u8; 4] = [b'I', b'E', b'N', b'D'];
 
 /// The representation of a Png image
 #[derive(Debug, Clone, PartialEq)]
@@ -38,7 +39,15 @@ impl Png {
         let mut chunks = Vec::with_capacity(8);
         while !b.is_empty() {
             let chunk = PngChunk::from_bytes(&mut b)?;
+
+            // Often PNG images found in the internet contain garbage after IEND chunk.
+            // Most PNG parser simply ignore everything after IEND chunk
+            let is_end = chunk.kind() == CHUNK_IEND;
             chunks.push(chunk);
+
+            if is_end {
+                break;
+            }
         }
 
         Ok(Png { chunks })


### PR DESCRIPTION
Hi,

I've noticed that lots of PNG files found in the internet have garbage data after IEND chunk. Even though strictly speaking these are invalid PNGs, browsers, image editors and other PNG libraries open them just fine.

As far as I understand, libraries such as imagemagick, or rust `png` crate simply stop parsing after IEND chunk. In this PR I'm doing the same.